### PR TITLE
3d numpy arrays compression

### DIFF
--- a/mtscomp.py
+++ b/mtscomp.py
@@ -286,6 +286,7 @@ class Writer:
         if str(data_path).endswith('.npy'):
             # NPY files.
             self.data = np.load(data_path, mmap_mode='r')
+            self.shape = self.data.shape
             if self.data.ndim >= 3:
                 self.data = np.reshape(self.data, (-1, self.data.shape[-1]))
             self.dtype = dtype = self.data.dtype
@@ -300,8 +301,9 @@ class Writer:
                 raise ValueError("Please provide a dtype (-d option in the command-line).")
             self.dtype = np.dtype(dtype)
             self.data = load_raw_data(data_path, n_channels=n_channels, dtype=self.dtype)
+            self.shape = self.data.shape
 
-        self.sample_rate = sample_rate
+        self.sample_rate = float(sample_rate)
         assert sample_rate > 0
         assert n_channels > 0
         self.file_size = self.data.size * self.data.itemsize
@@ -350,6 +352,7 @@ class Writer:
             'chunk_order': self.chunk_order,
             'sha1_compressed': self.sha1_compressed.hexdigest(),
             'sha1_uncompressed': self.sha1_uncompressed.hexdigest(),
+            'shape': self.shape
         }
 
     def get_chunk(self, chunk_idx):

--- a/tests.py
+++ b/tests.py
@@ -421,6 +421,24 @@ def test_decompress_pool(path, arr):
     assert sorted(d3.keys()) == [0, 1, 3]
 
 
+def test_3d(path):
+    file_npy = path.parent.joinpath('titi.npy')
+    file_cnpy = path.parent.joinpath('titi.cnpy')
+    array = np.random.randint(-5000, high=5000, size=(100, 120, 130), dtype=np.int16)
+    np.save(file_npy, array)
+    # two way trip - makes sure that
+    # 1) the sample_rate fed as an int64 doesn't error
+    # 2) the initial shape of the array is saved in the meta-data
+    mtscomp_mod.compress(file_npy,
+                         out=file_cnpy,
+                         outmeta=file_cnpy.with_suffix('.ch'),
+                         sample_rate=np.prod(array.shape[1:]),  # here needs to cast as float
+                         dtype=array.dtype,
+                         do_time_diff=False)
+    d = mtscomp_mod.decompress(file_cnpy, cmeta=file_cnpy.with_suffix('.ch'))
+    assert np.all(np.isclose(d[:, :].reshape(d.cmeta.shape), array))
+
+
 #------------------------------------------------------------------------------
 # Read/write tests with different parameters
 #------------------------------------------------------------------------------


### PR DESCRIPTION
I had the need to use compression for storing brain volumes. Wanted to give a try with mtscomp.

Everything was already in place for npy file compression of an arbitrary number of dimensions, the array being 2d flattened before compression. There was just a lost of information about the initial shape of the array, so I added this in the cmeta dict/json.

I'm not sure we need a full blown 3D chunk by chunk decompression, so far let's leave the 2d to 3d indexing tricks to the eventual user and see when there is an eventual use case (on my end I decompress the full volumes at the moment, cf. the test case).

