### PR TITLE
Fix bug when using uint types for indexing

### DIFF
--- a/mtscomp.py
+++ b/mtscomp.py
@@ -656,7 +656,7 @@ class Reader:
             i += self.n_samples
         i = _clip(i, 0, self.n_samples)
         assert 0 <= i <= self.n_samples
-        return i
+        return int(i)
 
     def _chunks_for_interval(self, i0, i1):
         """Find the first and last chunks to be loaded in order to get the data between

--- a/tests.py
+++ b/tests.py
@@ -273,6 +273,14 @@ def test_reader_indexing_1(path, arr):
     items.extend([0, 1, N - 2, N - 1])  # N, N + 1, -1, -2])
     items.extend(np.random.randint(low=-N, high=N, size=100).tolist())
 
+    # Different integer types
+    inttypes = [np.uint64, np.int64, np.int8, int]
+    for t1 in inttypes:
+        for t2 in inttypes:
+            items.append(slice(t1(1), t2(3))) # Slices
+            for t3 in inttypes:
+                items.append(slice(t1(5), t2(9), t3(2))) # Slices with steps
+
     # For every item, check the decompression.
     for s in items:
         if isinstance(s, slice) and s.step is not None and s.step <= 0:


### PR DESCRIPTION
Description:

When using uints as indexes on Reader objects, there is a crash.

```
arr = mtscomp.decompress(...)
arr[np.uint64(1):np.uint64(5)]
```

Error output:

```
File "/opt/miniconda3/envs/ks4/lib/python3.9/site-packages/mtscomp.py", line 832, in __getitem__
    out = arr[a:b:item.step, :]
TypeError: slice indices must be integers or None or have an __index__ method
```

Fix description:

This is caused by [numpy promotion rules](https://numpy.org/neps/nep-0050-scalar-promotion.html) which specify that a uint minus an int is a float ([see line 828 of mtscomp.py](https://github.com/int-brain-lab/mtscomp/blob/d2c58fdb089fa4154f5b5dd6c1fcbaa8dec2da2e/mtscomp.py#L828)).  This fixes the issue by casting all int indices to numpy ints, which will never cause an overflow and will always promote to int.

Code includes a fix and new test cases.
